### PR TITLE
Write CandleInterval class

### DIFF
--- a/src/CandleInterval.ts
+++ b/src/CandleInterval.ts
@@ -1,0 +1,72 @@
+/**
+ * Represents the time frame between price candles
+ */
+class CandleInterval
+{
+	/**
+	 * Create a new CandleInterval from the given unit and amount
+	 * @param unit The unit of the interval
+	 * @param amount The amount of the interval
+	 */
+	constructor(public unit: CandleInterval.IntervalUnit, public amount: number)
+	{}
+
+	/**
+	 * Create a new CandleInterval from the given string
+	 * @param interval The string representation of the interval. Must be in the format of <amount><unit>
+	 * @returns A new CandleInterval from the parsed string
+	 */
+	static fromString(interval: string): CandleInterval
+	{
+		if (interval.length < 2)
+			throw new Error(`Invalid interval string: ${interval}`)
+
+		const unit = interval.slice(-1)
+		const amount = parseInt(interval.slice(0, -1))
+
+		if (isNaN(amount) || amount < 1)
+			throw new Error(`Invalid interval amount: ${amount}`)
+
+		if (!isValidUnit(unit))
+			throw new Error(`Invalid interval unit: ${interval}`)
+
+		return { amount: amount, unit: unit }
+	}
+
+	/**
+	 * Give a string representation of this interval
+	 * @returns A string in the format of <amount><unit>
+	 */
+	toString(): string
+	{
+		return `${this.amount}${this.unit}`
+	}
+}
+
+module CandleInterval
+{
+	/**
+	 * The time unit of a CandleInterval
+	 */
+	export const enum IntervalUnit
+	{
+		YEAR = 'y',
+		MONTH = 'M',
+		WEEK = 'w',
+		DAY = 'd',
+		HOUR = 'h',
+		MINUTE = 'm'
+	}
+}
+
+/**
+ * Determine if the given string is a valid interval unit
+ * @param unit The unit to check
+ * @returns True if the unit is valid, false otherwise
+ */
+function isValidUnit(unit: string): unit is CandleInterval.IntervalUnit
+{
+	return Object.values((CandleInterval as any).IntervalUnit).includes(unit)
+}
+
+export default CandleInterval

--- a/test/CandleInterval.test.ts
+++ b/test/CandleInterval.test.ts
@@ -1,0 +1,61 @@
+import CandleInterval from '../src/CandleInterval'
+
+describe('CandleInterval', () =>
+{
+	test('should be able to create a new CandleInterval', () =>
+	{
+		for (const unit of Object.values((CandleInterval as any).IntervalUnit))
+		{
+			const interval = new CandleInterval(unit as CandleInterval.IntervalUnit, 1)
+			expect(interval.unit).toBe(unit)
+			expect(interval.amount).toBe(1)
+		}
+	})
+})
+
+describe('CandleInterval.toString', () =>
+{
+	test('should return a string representation of the interval', () =>
+	{
+		for (const unit of Object.values((CandleInterval as any).IntervalUnit))
+		{
+			const interval = new CandleInterval(unit as CandleInterval.IntervalUnit, 1)
+			expect(interval.toString()).toBe(`1${unit}`)
+		}
+	})
+})
+
+describe('CandleInterval.fromString', () =>
+{
+	test('should be able to create a CandleInterval from a string', () =>
+	{
+		const interval = CandleInterval.fromString('5m')
+		expect(interval.unit).toBe(CandleInterval.IntervalUnit.MINUTE)
+		expect(interval.amount).toBe(5)
+	})
+
+	test('should re-create a CandleInterval from its toString representation', () =>
+	{
+		for (const unit of Object.values((CandleInterval as any).IntervalUnit))
+		{
+			const interval = new CandleInterval(unit as CandleInterval.IntervalUnit, 1)
+			expect(CandleInterval.fromString(interval.toString())).toEqual(interval)
+		}
+	})
+
+	test('should throw an error if the string is too short', () =>
+	{
+		expect(() => CandleInterval.fromString('')).toThrowError()
+	})
+
+	test('should throw an error if the string has an invalid interval', () =>
+	{
+		expect(() => CandleInterval.fromString('5x')).toThrowError()
+	})
+
+	test('should throw an error if the string has an invalid amount', () =>
+	{
+		expect(() => CandleInterval.fromString('-1m')).toThrowError()
+		expect(() => CandleInterval.fromString(`${Math.sqrt(-1)}s`)).toThrowError()
+	})
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "target": "es2017",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "preserveConstEnums": true
   },
   "include": ["./src/**/*", "./pairs/**/*"],
 }


### PR DESCRIPTION
Wrote a CandleInterval class, to represent a time interval between price candles of a trading pair. The interval is represented by an amount and a time frame, so candles can be for "5m", "1d", and "4h", for example.

The time unit is represented by a const enum. The "const" part makes it so that in the transpiled javascript, the actual values are used instead of the enum names, for a possible slight performance increase. However, the "preserveConstEnums" option was enabled in the TypeScript config, to allow the enum names to still be used, which is helpful for the tests.