### PR TITLE
Write test scripts for separate log and main tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,35 +35,8 @@ jobs:
     - name: Install Packages
       run: npm i
 
-    - name: Make Coverage Directory for Generated JSON
-      run: mkdir coverage-to-merge
-
-    - name: Run Log Tests
-      run: npx jest --config jest.config.ts test/customLog.test.ts --coverage
-
-    - name: Move customLog Coverage to Folder
-      run: mv coverage/coverage-final.json coverage-to-merge/customLog.json
-
-    - name: Remove Coverage Folder
-      run: rm -rf coverage
-      
-    - name: Run Other Tests
-      run: npx jest --config jest.config.ts --testPathIgnorePatterns=customLog.test.ts --coverage
-
-    - name: Move Other Coverage to Folder
-      run: mv coverage/coverage-final.json coverage-to-merge/other.json
-
-    - name: Remove Coverage Folder
-      run: rm -rf coverage
-
-    - name: Merge Coverage Reports
-      run: npx nyc merge coverage-to-merge/ merged-coverage/merged-coverage.json
-
-    - name: Generate Full Coverage Report
-      run: npx nyc report -t merged-coverage/ --report-dir coverage --reporter=lcov --reporter=text --reporter=cobertura
-
-    - name: Clean Up Utility Folders
-      run: rm -rf coverage-to-merge merged-coverage
+    - name: Run Tests and Generate Coverage
+      run: npm run cov
       
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -4,7 +4,16 @@
   "description": "A Node.js cryptocurrency trading bot framework.",
   "main": "index.ts",
   "scripts": {
-    "test": "jest ./test --config jest.config.ts",
+    "test-main": "jest test/ --config jest.config.ts --testPathIgnorePatterns=customLog.test.ts",
+    "cov-main": "mkdir -p coverage/to-merge && npm run test-main -- --coverage --coverageDirectory=coverage/main/ && cp coverage/main/coverage-final.json coverage/to-merge/main.json",
+
+    "test-log": "jest test/customLog.test.ts --config jest.config.ts",
+    "cov-log": "mkdir -p coverage/to-merge && npm run test-log -- --coverage --coverageDirectory=coverage/log/ && cp coverage/log/coverage-final.json coverage/to-merge/log.json",
+
+    "merge-cov": "npx nyc merge coverage/to-merge coverage/output.json && npx nyc report -t coverage/ --report-dir coverage/ --reporter=lcov --reporter=text --reporter=cobertura",
+    "test": "npm run test-main && npm run test-log",
+    "cov": "npm run cov-main && npm run cov-log && npm run merge-cov",
+
     "build": "tsc",
     "live-build": "tsc --watch",
     "start": "node built/src/index.js"


### PR DESCRIPTION
`test-main`: Run all tests except `customLog.test.ts`.
`cov-main`: Generage coverage for all tests except `customLog.test.ts`, and output to the `coverage/main` directory. Move the generated JSON file to `coverage/to-merge/main.json`.

`test-log`: Run tests on only `customLog.test.ts`.
`cov-log`: Generate coverage for only `customLog.test.ts`, and output to the `coverage/log` directory. Move the generated JSON file to `coverage/to-merge/log.json`.

`merge-cov`: Merge the `coverage/to-merge/[main|log].json` reports into one file, `coverage/output.json`. Then generate text, LCOV, and HTML reports from the JSON file.
`test`: Test everything. Runs main and log tests in sequence.
`cov`: Generate coverage on everything. Runs `cov-main` and `cov-log`, then `merge-cov`.

See #11 for explanation of why tests are split up like this.